### PR TITLE
add getStaticPaths

### DIFF
--- a/lib/data-sites.js
+++ b/lib/data-sites.js
@@ -186,7 +186,7 @@ export const allSites = [
       "<b>...</b> Im Jahr 1988 verkaufte Hertie das Gelände weiter. Während der Arbeiten für ein Einkaufszentrum 1991 wurden die Spuren des ehemaligen Friedhofs sichtbar, Bruchstücke von Grabsteinen und menschliche Knochenreste kamen an die Oberfläche. Internationale jüdische Gemeinden wurden auf das Bauprojekt aufmerksam und protestierten gegen weitere Schändung, es kam zu einem vorübergehenden Baustopp. Schließlich einigte man sich auf den Schlichterspruch des Jerusalemer Oberrabbiners, so wurde anstatt einer Tiefgarage ein Parkhaus auf dem Dach des Gebäudes errichtet und auf das Erdreich, in dem Gräber und Gebeine vermutet wurden, eine Betonplatte gegossen. Im Untergeschoss des Mercados befindet sich eine Gedenktafel, die über die Geschichte des Friedhofs informiert.",
     ],
     quote:
-      "„Darum ist diese Eure Begräbnisstätte, <br/>wo Ihr zum Schlummer gebettet wurdet <br/>bis zur Stunde Eurer Auferstehung, <br/>wie ein Heiligtum geachtet <br/>in den Augen aller Kinder Eurer Gemeinde <br/>und wir glaubten in unserer Seele, <br/>daß ein Haus der Ewigkeiten <br/>Eure Ruhestätte sei, <br/>wo Ihr schlafet und niemand aufstört <br/>den Frieden eures Schlummers.“",
+      "„Darum ist diese Eure Begräbnisstätte, wo Ihr zum Schlummer gebettet wurdet bis zur Stunde Eurer Auferstehung, wie ein Heiligtum geachtet in den Augen aller Kinder Eurer Gemeinde und wir glaubten in unserer Seele, daß ein Haus der Ewigkeiten Eure Ruhestätte sei, wo Ihr schlafet und niemand aufstört den Frieden eures Schlummers.“",
     quoteSource:
       "Joseph Carlebach: <br/>Gebet vor Exhumierung, Jahrbuch für die Jüdischen Gemeinden, 1937/38",
     currentPicture: ["/images/5_MG_1781.jpg", "/images/5_MG_1774.jpg"],

--- a/pages/singlesite/[slug].js
+++ b/pages/singlesite/[slug].js
@@ -1,21 +1,18 @@
 import Link from "next/link";
 import Image from "next/image";
 import styled from "styled-components";
-import { useRouter } from "next/router";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper";
 import "swiper/css";
 import "swiper/css/pagination";
 
 import { allSites } from "../../lib/data-sites";
-
-export default function singleSite() {
-  const router = useRouter();
-  const slug = router.query.slug;
-  if (!slug) {
-    return null;
-  }
+export default function singleSite({ slug }) {
   const currentSite = allSites.find((site) => site.slug === slug);
+  const siteCurrents = currentSite.currentPicture;
+  const ancientPictArr = currentSite.ancientPicture;
+  const siteInformations = currentSite.information;
+  const siteCredits = currentSite.credits;
 
   if (!currentSite) {
     return (
@@ -24,10 +21,6 @@ export default function singleSite() {
       </>
     );
   }
-  const ancientPictArr = currentSite.ancientPicture;
-  const siteInformations = currentSite.information;
-  const siteCredits = currentSite.credits;
-  const siteCurrents = currentSite.currentPicture;
 
   return (
     <StyledContainer>
@@ -175,6 +168,26 @@ export default function singleSite() {
     </StyledContainer>
   );
 }
+export async function getStaticPaths() {
+  return {
+    paths: [
+      { params: { slug: "1" } },
+      { params: { slug: "2" } },
+      { params: { slug: "3" } },
+      { params: { slug: "4" } },
+      { params: { slug: "5" } },
+      { params: { slug: "6" } },
+      { params: { slug: "7" } },
+    ],
+    fallback: false,
+  };
+}
+export async function getStaticProps(context) {
+  return {
+    props: { slug: context.params.slug },
+  };
+}
+
 const StyledContainer = styled.div`
   display: flex;
 `;


### PR DESCRIPTION
I had some problems, adding static paths should solve them:
The problem was, how I wanted to use the [slug].js page in pages/singlesite and how Next is working under the hood.

At build time, when vercel is deploying the project, [slug].js is empty, because no one is visiting the site and next doesn't know what [slug] holds. And therefor the build process is throwing the error.

You can tell Next how to handle dynamic path during the build process. Like -> "hey next, I know every slug/id and have every information here to build singlesite/1 to singlesite/7. Or you don't know it and next needs to build the pages at every request.

And Next has you covered. Take a look at [getStaticPaths](https://nextjs.org/docs/basic-features/data-fetching/get-static-paths) from the official next documentation.